### PR TITLE
new: usr: Include version-specific converters.

### DIFF
--- a/kismetdb/alerts.py
+++ b/kismetdb/alerts.py
@@ -31,6 +31,12 @@ class Alerts(BaseInterface):
             which builds the SQL partial and replacement dictionary.
         field_defaults (dict): Statically set these column defaults by DB
             version.
+        converters_reference (dict): This provides a reference for converters
+            to use on data coming from the DB on a version by version basis.
+        full_query_column_names (list): Processed column names for full query
+            of kismet DB. Created on instantiation.
+        meta_query_column_names (list): Processed column names for meta query
+            of kismet DB. Created on instantiation.
 
     """
 
@@ -38,6 +44,9 @@ class Alerts(BaseInterface):
     bulk_data_field = "json"
     field_defaults = {4: {},
                       5: {}}
+    converters_reference = {4: {"lat": Utility.format_int_as_latlon,
+                                "lon": Utility.format_int_as_latlon},
+                            5: {}}
     column_reference = {4: ["ts_sec", "ts_usec", "phyname", "devmac", "lat",
                             "lon", "header", "json"],
                         5: ["ts_sec", "ts_usec", "phyname", "devmac", "lat",

--- a/kismetdb/data_sources.py
+++ b/kismetdb/data_sources.py
@@ -31,6 +31,12 @@ class DataSources(BaseInterface):
             which builds the SQL partial and replacement dictionary.
         field_defaults (dict): Statically set these column defaults by DB
             version.
+        converters_reference (dict): This provides a reference for converters
+            to use on data coming from the DB on a version by version basis.
+        full_query_column_names (list): Processed column names for full query
+            of kismet DB. Created on instantiation.
+        meta_query_column_names (list): Processed column names for meta query
+            of kismet DB. Created on instantiation.
 
     """
 
@@ -38,6 +44,8 @@ class DataSources(BaseInterface):
     bulk_data_field = "json"
     field_defaults = {4: {},
                       5: {}}
+    converters_reference = {4: {},
+                            5: {}}
     column_reference = {4: ["uuid", "typestring", "definition", "name",
                             "interface", "json"],
                         5: ["uuid", "typestring", "definition", "name",

--- a/kismetdb/devices.py
+++ b/kismetdb/devices.py
@@ -1,6 +1,4 @@
 """Devices abstraction."""
-import json
-
 from .base_interface import BaseInterface
 from .utility import Utility
 
@@ -52,6 +50,12 @@ class Devices(BaseInterface):
             which builds the SQL partial and replacement dictionary.
         field_defaults (dict): Statically set these column defaults by DB
             version.
+        converters_reference (dict): This provides a reference for converters
+            to use on data coming from the DB on a version by version basis.
+        full_query_column_names (list): Processed column names for full query
+            of kismet DB. Created on instantiation.
+        meta_query_column_names (list): Processed column names for meta query
+            of kismet DB. Created on instantiation.
 
     """
 
@@ -59,6 +63,14 @@ class Devices(BaseInterface):
     bulk_data_field = "device"
     field_defaults = {4: {},
                       5: {}}
+    converters_reference = {4: {"device": Utility.device_field_parser,
+                                "min_lat": Utility.format_int_as_latlon,
+                                "min_lon": Utility.format_int_as_latlon,
+                                "max_lat": Utility.format_int_as_latlon,
+                                "max_lon": Utility.format_int_as_latlon,
+                                "avg_lat": Utility.format_int_as_latlon,
+                                "avg_lon": Utility.format_int_as_latlon},
+                            5: {"device": Utility.device_field_parser}}
     column_reference = {4: ["first_time", "last_time", "devkey", "phyname",
                             "devmac", "strongest_signal", "min_lat", "min_lon",
                             "max_lat", "max_lon", "avg_lat", "avg_lon",
@@ -79,11 +91,3 @@ class Devices(BaseInterface):
                     "strongest_signal_gt": Utility.generate_single_int_sql_gt,
                     "bytes_data_lt": Utility.generate_single_int_sql_lt,
                     "bytes_data_gt": Utility.generate_single_int_sql_gt}
-    bulk_parser = "device_bulk_parser"
-
-    @classmethod
-    def device_bulk_parser(cls, device):
-        """We ensure that a json-parseable string gets passed up the stack."""
-        retval = device
-        retval = json.dumps(json.loads(device))
-        return retval

--- a/kismetdb/packets.py
+++ b/kismetdb/packets.py
@@ -47,6 +47,12 @@ class Packets(BaseInterface):
             which builds the SQL partial and replacement dictionary.
         field_defaults (dict): Statically set these column defaults by DB
             version.
+        converters_reference (dict): This provides a reference for converters
+            to use on data coming from the DB on a version by version basis.
+        full_query_column_names (list): Processed column names for full query
+            of kismet DB. Created on instantiation.
+        meta_query_column_names (list): Processed column names for meta query
+            of kismet DB. Created on instantiation.
 
     """
 
@@ -56,6 +62,9 @@ class Packets(BaseInterface):
                           "speed": 0,
                           "heading": 0},
                       5: {}}
+    converters_reference = {4: {"lat": Utility.format_int_as_latlon,
+                                "lon": Utility.format_int_as_latlon},
+                            5: {}}
     column_reference = {4: ["ts_sec", "ts_usec", "phyname", "sourcemac",
                             "destmac", "transmac", "frequency", "devkey",
                             "lat", "lon", "packet_len", "signal", "datasource",

--- a/kismetdb/utility.py
+++ b/kismetdb/utility.py
@@ -1,5 +1,6 @@
 """General utility functions that are shared between other classes."""
 import datetime
+import json
 import sys
 
 from dateutil import parser as dateparser
@@ -141,9 +142,8 @@ class Utility(object):
         This is used to get the lat or lon from the DB into the form other
         tools will more readily accept.
         """
-        in_val = int(lat_or_lon)
-        result = in_val / 100000.0
-        return float(result)
+        result = int(lat_or_lon) / 100000.0
+        return result
 
     @classmethod
     def generate_single_string_sql_eq(cls, column_name, filter_value):
@@ -342,3 +342,10 @@ class Utility(object):
         else:
             result = True if isinstance(target, (str, bytes)) else False
         return result
+
+    @classmethod
+    def device_field_parser(cls, device):
+        """We ensure that a json-parseable string gets passed up the stack."""
+        retval = device
+        retval = json.dumps(json.loads(device))
+        return retval

--- a/tests/integration/test_integration_alerts_4.py
+++ b/tests/integration/test_integration_alerts_4.py
@@ -16,6 +16,9 @@ class TestIntegrationAlerts(object):
         abstraction = kismetdb.Alerts(test_db)
         all_alerts = abstraction.get_all()
         assert all_alerts
+        for alert in all_alerts:
+            assert isinstance(alert["lat"], float)
+            assert isinstance(alert["lon"], float)
 
     def test_integration_alerts_get_all_date_filter(self):
         here_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/integration/test_integration_alerts_5.py
+++ b/tests/integration/test_integration_alerts_5.py
@@ -16,6 +16,9 @@ class TestIntegrationAlerts(object):
         abstraction = kismetdb.Alerts(test_db)
         all_alerts = abstraction.get_all()
         assert all_alerts
+        for alert in all_alerts:
+            assert isinstance(alert["lat"], float)
+            assert isinstance(alert["lon"], float)
 
     def test_integration_alerts_get_all_date_filter(self):
         here_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/integration/test_integration_devices_4.py
+++ b/tests/integration/test_integration_devices_4.py
@@ -14,8 +14,15 @@ class TestIntegrationDevices(object):
         here_dir = os.path.dirname(os.path.abspath(__file__))
         test_db = os.path.join(here_dir, "../assets/testdata.kismet_4")
         abstraction = kismetdb.Devices(test_db)
-        all_alerts = abstraction.get_all()
-        assert all_alerts
+        all_devices = abstraction.get_all()
+        assert all_devices
+        for device in all_devices:
+            assert isinstance(device["min_lat"], float)
+            assert isinstance(device["min_lon"], float)
+            assert isinstance(device["max_lat"], float)
+            assert isinstance(device["max_lon"], float)
+            assert isinstance(device["avg_lat"], float)
+            assert isinstance(device["avg_lon"], float)
 
     def test_integration_devices_get_all_date_filter(self):
         here_dir = os.path.dirname(os.path.abspath(__file__))
@@ -45,11 +52,17 @@ class TestIntegrationDevices(object):
         here_dir = os.path.dirname(os.path.abspath(__file__))
         test_db = os.path.join(here_dir, "../assets/testdata.kismet_4")
         abstraction = kismetdb.Devices(test_db)
-        for alert in abstraction.yield_meta(first_time_gt="2018-01-01",
-                                            phyname=["Bluetooth",
-                                                     "IEEE802.11"]):
-            assert alert
-            assert "device" not in alert
+        for device in abstraction.yield_meta(first_time_gt="2018-01-01",
+                                             phyname=["Bluetooth",
+                                                      "IEEE802.11"]):
+            assert device
+            assert "device" not in device
+            assert isinstance(device["min_lat"], float)
+            assert isinstance(device["min_lon"], float)
+            assert isinstance(device["max_lat"], float)
+            assert isinstance(device["max_lon"], float)
+            assert isinstance(device["avg_lat"], float)
+            assert isinstance(device["avg_lon"], float)
 
     def test_integration_devices_yield_meta(self):
         here_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/integration/test_integration_devices_5.py
+++ b/tests/integration/test_integration_devices_5.py
@@ -45,11 +45,17 @@ class TestIntegrationDevices(object):
         here_dir = os.path.dirname(os.path.abspath(__file__))
         test_db = os.path.join(here_dir, "../assets/testdata.kismet_5")
         abstraction = kismetdb.Devices(test_db)
-        for alert in abstraction.yield_meta(first_time_gt="2018-01-01",
-                                            phyname=["Bluetooth",
-                                                     "IEEE802.11"]):
-            assert alert
-            assert "device" not in alert
+        for device in abstraction.yield_meta(first_time_gt="2018-01-01",
+                                             phyname=["Bluetooth",
+                                                      "IEEE802.11"]):
+            assert device
+            assert "device" not in device
+            assert isinstance(device["min_lat"], float)
+            assert isinstance(device["min_lon"], float)
+            assert isinstance(device["max_lat"], float)
+            assert isinstance(device["max_lon"], float)
+            assert isinstance(device["avg_lat"], float)
+            assert isinstance(device["avg_lon"], float)
 
     def test_integration_devices_yield_meta(self):
         here_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/integration/test_integration_packets_4.py
+++ b/tests/integration/test_integration_packets_4.py
@@ -20,6 +20,8 @@ class TestIntegrationPackets(object):
             assert packet["alt"] == 0
             assert packet["speed"] == 0
             assert packet["heading"] == 0
+            assert isinstance(packet["lat"], float)
+            assert isinstance(packet["lon"], float)
 
     def test_integration_packets_yield_meta(self):
         here_dir = os.path.dirname(os.path.abspath(__file__))
@@ -32,3 +34,5 @@ class TestIntegrationPackets(object):
             assert packet["speed"] == 0
             assert packet["heading"] == 0
             assert packet["ts_sec"] != 0
+            assert isinstance(packet["lat"], float)
+            assert isinstance(packet["lon"], float)


### PR DESCRIPTION
This allows us to, for instance, ensure that all
GPS coordinates are returned as float-type values,
across all database versions, no matter how they
were originally stored in the database.

Closes #22